### PR TITLE
Space Travelers Hub: Switch badges for Rockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Space Traveler's Hub
 
-In this project when a a user clicks on Rockets that have already been reserved a "Reserved" badge is displayed and "Cancel reservation" button instead of the default "Reserve rocket".
+In this project when a user clicks on Rockets that have already been reserved a "Reserved" badge is displayed and "Cancel reservation" button instead of the default "Reserve rocket".
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Space Traveler's Hub
 
-In this project when a user clicks the "Reserve rocket" button,an  action is dispatched to update the store.
+In this project when a a user clicks on Rockets that have already been reserved a "Reserved" badge is displayed and "Cancel reservation" button instead of the default "Reserve rocket".
 
 ## Built With
 

--- a/src/components/Rockets/Rockets.css
+++ b/src/components/Rockets/Rockets.css
@@ -16,3 +16,7 @@
   height: 150px;
   width: 200px;
 }
+.reserved{
+  background-color: green;
+  color: #fff;
+}

--- a/src/components/Rockets/Rockets.css
+++ b/src/components/Rockets/Rockets.css
@@ -16,7 +16,8 @@
   height: 150px;
   width: 200px;
 }
-.reserved{
+
+.reserved {
   background-color: green;
   color: #fff;
 }

--- a/src/components/Rockets/Rockets.js
+++ b/src/components/Rockets/Rockets.js
@@ -19,7 +19,7 @@ const Rockets = () => {
               <h3>{name}</h3>
               <p className="reserve-sect">
                 {reserved === true && (
-                <span className="reverved">
+                <span className="reserved">
                   Reserved
                 </span>
                 )}


### PR DESCRIPTION
In this project when a user clicks on Rockets that have already been reserved ,a "Reserved" badge is displayed and "Cancel reservation" button instead of the default "Reserve rocket".

# Built With
- React
- Redux